### PR TITLE
Add controls for toggling playlist display and playback

### DIFF
--- a/apprenticevideo/CMakeLists.txt
+++ b/apprenticevideo/CMakeLists.txt
@@ -92,6 +92,7 @@ find_library(GLEW_LIBRARY GLEW
 
 set(project_moc_hxx
   yaeCanvasWidget.h
+  yaeControlsView.h
   yaeFlickableArea.h
   yaeItemView.h
   yaeMainWindow.h
@@ -136,6 +137,8 @@ set(project_sources
   yaeCanvasRenderer.h
   yaeCanvasRenderer.cpp
   yaeColor.h
+  yaeControlsView.cpp
+  yaeControlsView.h
   yaeExpression.h
   yaeFlickableArea.cpp
   yaeFlickableArea.h

--- a/apprenticevideo/yaeControlsView.cpp
+++ b/apprenticevideo/yaeControlsView.cpp
@@ -1,0 +1,247 @@
+// -*- Mode: c++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil -*-
+// NOTE: the first line of this file sets up source code indentation rules
+// for Emacs; it is also a hint to anyone modifying this file.
+
+// Created      : Fri Jan 22 19:20:22 PST 2016
+// Copyright    : Pavel Koshevoy
+// License      : MIT -- http://www.opensource.org/licenses/mit-license.php
+
+// Qt includes:
+#include <QPalette>
+
+// local includes:
+#include "yaeColor.h"
+#include "yaeControlsView.h"
+#include "yaeItemRef.h"
+#include "yaeMainWindow.h"
+#include "yaePlaylistView.h"
+#include "yaePlaylistViewStyle.h"
+#include "yaeProperty.h"
+#include "yaeRectangle.h"
+#include "yaeRoundRect.h"
+#include "yaeSegment.h"
+#include "yaeTexturedRect.h"
+
+
+namespace yae
+{
+
+  //----------------------------------------------------------------
+  // ControlsVisible
+  //
+  struct ControlsVisible : public TBoolExpr
+  {
+    ControlsVisible(ControlsView & view, Item & controls):
+      view_(view),
+      controls_(controls)
+    {}
+
+    // virtual:
+    void evaluate(bool & result) const
+    {
+      const TVec2D & pt = view_.mousePt();
+      result = controls_.overlaps(pt);
+    }
+
+    ControlsView & view_;
+    Item & controls_;
+  };
+
+  //----------------------------------------------------------------
+  // OnPlaybackPaused
+  //
+  struct OnPlaybackPaused : public TBoolExpr
+  {
+    OnPlaybackPaused(ControlsView & view, bool result):
+      view_(view),
+      result_(result)
+    {}
+
+    // virtual:
+    void evaluate(bool & result) const
+    {
+      bool paused = (view_.mainWindow_ == NULL ||
+                     view_.mainWindow_->isPlaybackPaused());
+      result = paused ? result_ : !result_;
+    }
+
+    ControlsView & view_;
+    bool result_;
+  };
+
+  //----------------------------------------------------------------
+  // TogglePlayback
+  //
+  struct TogglePlayback : public ClickableItem
+  {
+    TogglePlayback(ControlsView & view):
+      ClickableItem("toggle_playback"),
+      view_(view)
+    {}
+
+    // virtual:
+    bool onClick(const TVec2D & itemCSysOrigin,
+                 const TVec2D & rootCSysPoint)
+    {
+      std::cerr << "FIXME: TogglePlayback" << std::endl;
+      return true;
+    }
+
+    ControlsView & view_;
+  };
+
+
+  //----------------------------------------------------------------
+  // ControlsView::ControlsView
+  //
+  ControlsView::ControlsView():
+    ItemView("controls"),
+    mainWindow_(NULL),
+    playlist_(NULL)
+  {}
+
+  //----------------------------------------------------------------
+  // ControlsView::setPlaylistView
+  //
+  void
+  ControlsView::setup(MainWindow * mainWindow, PlaylistView * playlist)
+  {
+    if (!(mainWindow && playlist))
+    {
+      YAE_ASSERT(false);
+      return;
+    }
+
+    YAE_ASSERT(!mainWindow_);
+    mainWindow_ = mainWindow;
+
+    YAE_ASSERT(!playlist_);
+    playlist_ = playlist;
+
+
+    Item & root = *root_;
+
+    ColorRef color = root.addExpr
+      (new StyleColor(*playlist, PlaylistViewStyle::kFg, 0, 0.5));
+
+    // re-apply style when playlist is enabled or disabled:
+    playlist_->root()->
+      addObserver(Item::kOnToggleItemView,
+                  Item::TObserverPtr(new Repaint(*this, true)));
+
+    Item & container = root.addNew<Item>("container");
+    container.anchors_.fill(root);
+    container.anchors_.top_.reset();
+    container.height_ = container.
+      addExpr(new StyleTitleHeight(*playlist), 1.5);
+
+    Item & controls = root.addNew<Item>("controls");
+    controls.anchors_.hcenter_ =
+      ItemRef::reference(container, kPropertyHCenter);
+    controls.anchors_.vcenter_ =
+      ItemRef::reference(container, kPropertyVCenter);
+    controls.height_ = controls.
+      addExpr(new StyleTitleHeight(*playlist), 0.67);
+    controls.width_ = ItemRef::scale(controls, kPropertyHeight, 1.0);
+
+    Item & playbackButton = controls.addNew<Item>("playbackButton");
+    {
+      playbackButton.anchors_.top_ =
+        ItemRef::reference(controls, kPropertyTop);
+
+      playbackButton.anchors_.left_ =
+        ItemRef::reference(controls, kPropertyLeft);
+
+      playbackButton.height_ = playbackButton.addExpr
+        (new OddRoundUp(controls, kPropertyHeight));
+
+      playbackButton.width_ =
+        ItemRef::reference(playbackButton, kPropertyHeight);
+
+      TexturedRect & play = playbackButton.add(new TexturedRect("play"));
+      play.anchors_.fill(playbackButton);
+      play.visible_ = play.addExpr(new OnPlaybackPaused(*this, true));
+      play.texture_ = play.addExpr(new StyleCollapsedTexture(*playlist));
+
+      Item & pause = playbackButton.addNew<Item>("pause");
+      pause.anchors_.fill(playbackButton);
+      pause.visible_ = pause.addExpr(new OnPlaybackPaused(*this, false));
+      {
+        Rectangle & p1 = pause.addNew<Rectangle>("p1");
+        p1.anchors_.left_ = ItemRef::reference(pause, kPropertyLeft);
+        p1.anchors_.top_ = ItemRef::reference(pause, kPropertyTop);
+        p1.width_ = ItemRef::scale(pause, kPropertyWidth, 0.3);
+        p1.height_ = ItemRef::reference(pause, kPropertyHeight);
+        p1.margins_.left_ = p1.width_;
+        p1.color_ = color;
+
+        Rectangle & p2 = pause.addNew<Rectangle>("p2");
+        p2.anchors_.left_ = ItemRef::reference(p1, kPropertyRight);
+        p2.anchors_.top_ = ItemRef::reference(pause, kPropertyTop);
+        p2.width_ = p1.width_;
+        p2.height_ = ItemRef::reference(pause, kPropertyHeight);
+        p2.margins_.left_ = p1.width_;
+        p2.color_ = color;
+      }
+    }
+
+    TogglePlayback & playback = controls.add(new TogglePlayback(*this));
+    playback.anchors_.fill(playbackButton);
+  }
+
+  //----------------------------------------------------------------
+  // ControlsView::resizeTo
+  //
+  bool
+  ControlsView::resizeTo(const Canvas * canvas)
+  {
+    if (!ItemView::resizeTo(canvas))
+    {
+      return false;
+    }
+
+    if (playlist_)
+    {
+      PlaylistViewStyle & style = playlist_->playlistViewStyle();
+      requestUncache(&style);
+    }
+
+    return true;
+  }
+
+  //----------------------------------------------------------------
+  // ControlsView::processMouseTracking
+  //
+  bool
+  ControlsView::processMouseTracking(const TVec2D & mousePt)
+  {
+    (void)mousePt;
+
+    if (!this->isEnabled())
+    {
+      return false;
+    }
+
+    Item & root = *root_;
+    Item & controls = root["controls"];
+
+    Item & playbackButton = controls["playbackButton"];
+    requestUncache(&playbackButton);
+
+    return true;
+  }
+
+  //----------------------------------------------------------------
+  // ControlsView::controlsChanged
+  //
+  void
+  ControlsView::controlsChanged()
+  {
+    if (this->isEnabled())
+    {
+      this->requestUncache();
+      this->requestRepaint();
+    }
+  }
+
+}

--- a/apprenticevideo/yaeControlsView.h
+++ b/apprenticevideo/yaeControlsView.h
@@ -1,0 +1,62 @@
+// -*- Mode: c++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil -*-
+// NOTE: the first line of this file sets up source code indentation rules
+// for Emacs; it is also a hint to anyone modifying this file.
+
+// Created      : Fri Jan 22 19:20:22 PST 2016
+// Copyright    : Pavel Koshevoy
+// License      : MIT -- http://www.opensource.org/licenses/mit-license.php
+
+#ifndef YAE_CONTROLS_VIEW_H_
+#define YAE_CONTROLS_VIEW_H_
+
+// Qt interfaces:
+#include <QObject>
+
+// local interfaces:
+#include "yaeItemView.h"
+
+
+namespace yae
+{
+  // forward declarations:
+  class MainWindow;
+  class PlaylistView;
+
+  //----------------------------------------------------------------
+  // ControlsView
+  //
+  class YAE_API ControlsView : public ItemView
+  {
+    Q_OBJECT;
+
+  public:
+    ControlsView();
+
+    // need to reference playlist view for common style info:
+    void setup(MainWindow * mainWindow, PlaylistView * playlist);
+
+    // virtual: returns false if size didn't change
+    bool resizeTo(const Canvas * canvas);
+
+    // virtual:
+    bool processMouseTracking(const TVec2D & mousePt);
+
+    // accessors:
+    inline MainWindow * mainWindow() const
+    { return mainWindow_; }
+
+    inline PlaylistView * playlistView() const
+    { return playlist_; }
+
+  public slots:
+    void controlsChanged();
+
+  public:
+    MainWindow * mainWindow_;
+    PlaylistView * playlist_;
+  };
+
+}
+
+
+#endif // YAE_CONTROLS_VIEW_H_

--- a/apprenticevideo/yaeGridViewStyle.cpp
+++ b/apprenticevideo/yaeGridViewStyle.cpp
@@ -197,8 +197,25 @@ namespace yae
       title_height_.addExpr(new CalcTitleHeight(playlist_, 24.0));
 
     // generate an x-button texture:
-    QImage img = xbuttonImage(32, fg_xbutton_, bg_xbutton_.transparent());
-    xbutton_.setImage(img);
+    {
+      QImage img =
+        xbuttonImage(128, fg_xbutton_, bg_xbutton_.transparent());
+      xbutton_->setImage(img);
+    }
+
+    // generate collapsed group button texture:
+    {
+      QImage img =
+        triangleImage(128, fg_xbutton_, bg_xbutton_.transparent(), 90.0);
+      collapsed_->setImage(img);
+    }
+
+    // generate expanded group button texture:
+    {
+      QImage img =
+        triangleImage(128, fg_xbutton_, bg_xbutton_.transparent(), 180.0);
+      expanded_->setImage(img);
+    }
 
     cell_width_.width_ = cell_width_.
       addExpr(new GridCellWidth(playlist_), 1.0, -2.0);

--- a/apprenticevideo/yaeGridViewStyle.cpp
+++ b/apprenticevideo/yaeGridViewStyle.cpp
@@ -128,9 +128,11 @@ namespace yae
     filter_shadow_.reset(new TGradient());
     {
       TGradient & gradient = *filter_shadow_;
-      gradient[0.0] = Color(0x1f1f1f, 1.0);
-      gradient[0.42] = Color(0x1f1f1f, 0.9);
-      gradient[1.0] = Color(0x1f1f1f, 0.0);
+      gradient[0.000] = Color(0x1f1f1f, 1.0);
+      gradient[0.519] = Color(0x1f1f1f, 0.9);
+      gradient[0.520] = Color(0x000000, 0.5);
+      gradient[0.570] = Color(0x000000, 0.0);
+      gradient[1.000] = Color(0x000000, 0.0);
     }
 
     // timeline shadow gradient:
@@ -169,6 +171,9 @@ namespace yae
     bg_timecode_ = Color(0x7f7f7f, 0.25);
     fg_timecode_ = Color(0xFFFFFF, 0.5);
 
+    bg_controls_ = bg_timecode_;
+    fg_controls_ = fg_timecode_;
+
     bg_hint_ = Color(0x1f1f1f, 0.0);
     fg_hint_ = Color(0xffffff, 0.5);
 
@@ -206,15 +211,47 @@ namespace yae
     // generate collapsed group button texture:
     {
       QImage img =
-        triangleImage(128, fg_xbutton_, bg_xbutton_.transparent(), 90.0);
+        triangleImage(128, fg_group_, bg_group_.transparent(), 90.0);
       collapsed_->setImage(img);
     }
 
     // generate expanded group button texture:
     {
       QImage img =
-        triangleImage(128, fg_xbutton_, bg_xbutton_.transparent(), 180.0);
+        triangleImage(128, fg_group_, bg_group_.transparent(), 180.0);
       expanded_->setImage(img);
+    }
+
+    // generate pause button texture:
+    {
+      QImage img =
+        barsImage(128, fg_controls_, bg_controls_.transparent(), 2, 0.8);
+      pause_->setImage(img);
+    }
+
+    // generate play button texture:
+    {
+      QImage img =
+        triangleImage(128, fg_controls_, bg_controls_.transparent(), 90.0);
+      play_->setImage(img);
+    }
+
+    // generate playlist grid on button texture:
+    {
+      QImage img = barsImage(128,
+                             fg_controls_,
+                             bg_controls_.transparent(),
+                             3, 0.7, 90);
+      grid_on_->setImage(img);
+    }
+
+    // generate playlist grid off button texture:
+    {
+      QImage img = barsImage(128,
+                             fg_controls_.scale_a(0.5),
+                             bg_controls_.transparent(),
+                             3, 0.7, 90);
+      grid_off_->setImage(img);
     }
 
     cell_width_.width_ = cell_width_.

--- a/apprenticevideo/yaeGridViewStyle.cpp
+++ b/apprenticevideo/yaeGridViewStyle.cpp
@@ -98,11 +98,9 @@ namespace yae
     font_small_.setStyleHint(QFont::SansSerif);
     font_small_.setStyleStrategy((QFont::StyleStrategy)
                                  (QFont::PreferOutline |
-#if 0 // (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
-                                  QFont::NoSubpixelAntialias |
-#endif
                                   QFont::PreferAntialias |
                                   QFont::OpenGLCompatible));
+
     // main font:
     font_large_ = font_small_;
 

--- a/apprenticevideo/yaeImage.cpp
+++ b/apprenticevideo/yaeImage.cpp
@@ -213,8 +213,11 @@ namespace yae
   bool
   Image::TPrivate::uploadTexture(const Image & item)
   {
-    bool ok = yae::uploadTexture2D(image_->getImage(), texId_, iw_, ih_,
-                                   GL_LINEAR);
+    // upload texture:
+    QImage image = image_->getImage();
+    bool ok = yae::uploadTexture2D(image, texId_, GL_LINEAR);
+    iw_ = image.width();
+    ih_ = image.height();
 
     // no need to keep a duplicate image around once the texture is ready:
     image_->clearImage();

--- a/apprenticevideo/yaeInputArea.h
+++ b/apprenticevideo/yaeInputArea.h
@@ -133,6 +133,22 @@ namespace yae
   };
 
   //----------------------------------------------------------------
+  // ClickableItem
+  //
+  struct ClickableItem : public InputArea
+  {
+    ClickableItem(const char * id):
+      InputArea(id)
+    {}
+
+    // virtual:
+    bool onPress(const TVec2D & itemCSysOrigin,
+                 const TVec2D & rootCSysPoint)
+    { return true; }
+  };
+
+
+  //----------------------------------------------------------------
   // ModelInputArea
   //
   template <typename Model>
@@ -181,12 +197,12 @@ namespace yae
 
 
   //----------------------------------------------------------------
-  // ClickableItem
+  // ClickableModelItem
   //
   template <typename Model>
-  struct ClickableItem : public ModelInputArea<Model>
+  struct ClickableModelItem : public ModelInputArea<Model>
   {
-    ClickableItem(const char * id):
+    ClickableModelItem(const char * id):
       ModelInputArea<Model>(id)
     {}
 

--- a/apprenticevideo/yaeItem.cpp
+++ b/apprenticevideo/yaeItem.cpp
@@ -816,7 +816,7 @@ namespace yae
     if (anchors_.bottom_.isValid())
     {
       double b = anchors_.bottom_.get();
-      b += margins_.bottom_.get();
+      b -= margins_.bottom_.get();
       return b;
     }
 

--- a/apprenticevideo/yaeListViewStyle.cpp
+++ b/apprenticevideo/yaeListViewStyle.cpp
@@ -133,8 +133,25 @@ namespace yae
       title_height_.addExpr(new CalcTitleHeight(playlist_, 24.0));
 
     // generate an x-button texture:
-    QImage img = xbuttonImage(32, fg_xbutton_, bg_xbutton_.transparent(), 0.1);
-    xbutton_.setImage(img);
+    {
+      QImage img =
+        xbuttonImage(128, fg_xbutton_, bg_xbutton_.transparent(), 0.1);
+      xbutton_->setImage(img);
+    }
+
+    // generate collapsed group button texture:
+    {
+      QImage img =
+        triangleImage(128, fg_xbutton_, bg_xbutton_.transparent(), 90.0);
+      collapsed_->setImage(img);
+    }
+
+    // generate expanded group button texture:
+    {
+      QImage img =
+        triangleImage(128, fg_xbutton_, bg_xbutton_.transparent(), 180.0);
+      expanded_->setImage(img);
+    }
 
     cell_width_.width_ = cell_width_.
       addExpr(new GetScrollviewWidth(playlist_), 1.0, -2.0);

--- a/apprenticevideo/yaeListViewStyle.cpp
+++ b/apprenticevideo/yaeListViewStyle.cpp
@@ -105,6 +105,9 @@ namespace yae
     bg_timecode_ = Color(0xffffff, 0.5);
     fg_timecode_ = Color(0x3f3f3f, 0.5);
 
+    bg_controls_ = bg_timecode_;
+    fg_controls_ = fg_timecode_;
+
     bg_hint_ = Color(0xffffff, 0.0);
     fg_hint_ = Color(0x1f1f1f, 0.5);
 
@@ -142,15 +145,47 @@ namespace yae
     // generate collapsed group button texture:
     {
       QImage img =
-        triangleImage(128, fg_xbutton_, bg_xbutton_.transparent(), 90.0);
+        triangleImage(128, fg_group_, bg_group_.transparent(), 90.0);
       collapsed_->setImage(img);
     }
 
     // generate expanded group button texture:
     {
       QImage img =
-        triangleImage(128, fg_xbutton_, bg_xbutton_.transparent(), 180.0);
+        triangleImage(128, fg_group_, bg_group_.transparent(), 180.0);
       expanded_->setImage(img);
+    }
+
+    // generate pause button texture:
+    {
+      QImage img =
+        barsImage(128, fg_controls_, bg_controls_.transparent(), 2, 0.8);
+      pause_->setImage(img);
+    }
+
+    // generate play button texture:
+    {
+      QImage img =
+        triangleImage(128, fg_controls_, bg_controls_.transparent(), 90.0);
+      play_->setImage(img);
+    }
+
+    // generate playlist grid on button texture:
+    {
+      QImage img = barsImage(128,
+                             fg_controls_,
+                             bg_controls_.transparent(),
+                             3, 0.7, 90);
+      grid_on_->setImage(img);
+    }
+
+    // generate playlist grid off button texture:
+    {
+      QImage img = barsImage(128,
+                             fg_controls_.scale_a(0.3),
+                             bg_controls_.transparent(),
+                             3, 0.7, 90);
+      grid_off_->setImage(img);
     }
 
     cell_width_.width_ = cell_width_.

--- a/apprenticevideo/yaeListViewStyle.cpp
+++ b/apprenticevideo/yaeListViewStyle.cpp
@@ -30,19 +30,11 @@ namespace yae
     font_small_.setStyleHint(QFont::SansSerif);
     font_small_.setStyleStrategy((QFont::StyleStrategy)
                                  (QFont::PreferOutline |
-#if 0 // (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
-                                  QFont::NoSubpixelAntialias |
-#endif
                                   QFont::PreferAntialias |
                                   QFont::OpenGLCompatible));
 
     // main font:
     font_ = font_small_;
-
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-    font_.setWeight(78);
-#endif
-
     font_large_ = font_small_;
 
     static bool hasImpact =

--- a/apprenticevideo/yaeMainWindow.cpp
+++ b/apprenticevideo/yaeMainWindow.cpp
@@ -2399,6 +2399,8 @@ namespace yae
   void
   MainWindow::playbackShowTimeline()
   {
+    controlsView_.controlsChanged();
+
     bool showTimeline = actionShowTimeline->isChecked();
 
 #ifdef YAE_USE_PLAYER_QUICK_WIDGET

--- a/apprenticevideo/yaeMainWindow.cpp
+++ b/apprenticevideo/yaeMainWindow.cpp
@@ -403,9 +403,11 @@ namespace yae
     playerWidget_->setGreeting(greeting);
     playerWidget_->append(&playlistView_);
     playerWidget_->append(&timelineView_);
+    playerWidget_->append(&controlsView_);
     timelineView_.setPlaylistView(&playlistView_);
     playlistView_.setModel(&playlistModel_);
     timelineView_.setModel(&timelineModel_);
+    controlsView_.setup(this, &playlistView_);
 
     // add image://thumbnails/... provider:
     boost::shared_ptr<ThumbnailProvider>

--- a/apprenticevideo/yaeMainWindow.cpp
+++ b/apprenticevideo/yaeMainWindow.cpp
@@ -886,7 +886,7 @@ namespace yae
                  actionShowPlaylist, SLOT(trigger()));
     YAE_ASSERT(ok);
 
-     ok = connect(actionShowTimeline, SIGNAL(toggled(bool)),
+    ok = connect(actionShowTimeline, SIGNAL(toggled(bool)),
                  this, SLOT(playbackShowTimeline()));
     YAE_ASSERT(ok);
 
@@ -2366,6 +2366,8 @@ namespace yae
   void
   MainWindow::playbackShowPlaylist()
   {
+    controlsView_.controlsChanged();
+
     bool showPlaylist = actionShowPlaylist->isChecked();
 
 #ifdef YAE_USE_PLAYER_QUICK_WIDGET
@@ -2617,6 +2619,15 @@ namespace yae
   }
 
   //----------------------------------------------------------------
+  // MainWindow::togglePlaylist
+  //
+  void
+  MainWindow::togglePlaylist()
+  {
+    actionShowPlaylist->trigger();
+  }
+
+  //----------------------------------------------------------------
   // MainWindow::togglePlayback
   //
   void
@@ -2650,6 +2661,8 @@ namespace yae
       bookmarkTimer_.stop();
       saveBookmark();
     }
+
+    controlsView_.controlsChanged();
   }
 
   //----------------------------------------------------------------

--- a/apprenticevideo/yaeMainWindow.h
+++ b/apprenticevideo/yaeMainWindow.h
@@ -144,6 +144,9 @@ namespace yae
     inline bool isPlaylistVisible() const
     { return actionShowPlaylist->isChecked(); }
 
+    inline bool isTimelineVisible() const
+    { return actionShowTimeline->isChecked(); }
+
   signals:
     void setInPoint();
     void setOutPoint();

--- a/apprenticevideo/yaeMainWindow.h
+++ b/apprenticevideo/yaeMainWindow.h
@@ -32,6 +32,7 @@
 #ifndef YAE_USE_PLAYER_QUICK_WIDGET
 #include "yaeCanvasWidget.h"
 #endif
+#include "yaeControlsView.h"
 #include "yaePlaylist.h"
 #include "yaePlaylistModel.h"
 #include "yaePlaylistModelProxy.h"
@@ -136,6 +137,9 @@ namespace yae
     // specify a playlist of files to load:
     void setPlaylist(const std::list<QString> & playlist,
                      bool beginPlaybackImmediately = true);
+
+    inline bool isPlaybackPaused() const
+    { return playbackPaused_; }
 
   signals:
     void setInPoint();
@@ -356,6 +360,7 @@ namespace yae
     Canvas * canvas_;
     PlaylistView playlistView_;
     TimelineView timelineView_;
+    ControlsView controlsView_;
     TimelineModel timelineModel_;
     TPlaylistModel playlistModel_;
 

--- a/apprenticevideo/yaeMainWindow.h
+++ b/apprenticevideo/yaeMainWindow.h
@@ -141,6 +141,9 @@ namespace yae
     inline bool isPlaybackPaused() const
     { return playbackPaused_; }
 
+    inline bool isPlaylistVisible() const
+    { return actionShowPlaylist->isChecked(); }
+
   signals:
     void setInPoint();
     void setOutPoint();
@@ -197,6 +200,7 @@ namespace yae
     void enterFullScreen(Canvas::TRenderMode renderMode);
     void exitFullScreen();
     void exitPlaylist();
+    void togglePlaylist();
     void togglePlayback();
     void skipToInPoint();
     void skipToOutPoint();

--- a/apprenticevideo/yaePlaylistView.cpp
+++ b/apprenticevideo/yaePlaylistView.cpp
@@ -618,7 +618,8 @@ namespace yae
     Item & icon = filter.addNew<Item>("filter_icon");
     {
       RoundRect & circle = icon.addNew<RoundRect>("circle");
-      circle.anchors_.hcenter_ = ItemRef::scale(filter, kPropertyHeight, 1.5);
+      circle.anchors_.hcenter_ =
+        ItemRef::reference(filter, kPropertyHeight, 1.5, -4);
       circle.anchors_.vcenter_ = ItemRef::reference(filter, kPropertyVCenter);
       circle.width_ = ItemRef::scale(filter, kPropertyHeight, 0.5);
       circle.height_ = circle.width_;

--- a/apprenticevideo/yaePlaylistView.cpp
+++ b/apprenticevideo/yaePlaylistView.cpp
@@ -613,11 +613,12 @@ namespace yae
     filter.anchors_.bottom_.reset();
     filter.height_ = ItemRef::scale(item, kPropertyHeight, 0.333);
     filter.radius_ = ItemRef::scale(filter, kPropertyHeight, 0.1);
+    filter.margins_.left_ = ItemRef::offset(filter, kPropertyHeight, -4);
 
     Item & icon = filter.addNew<Item>("filter_icon");
     {
       RoundRect & circle = icon.addNew<RoundRect>("circle");
-      circle.anchors_.hcenter_ = ItemRef::scale(filter, kPropertyHeight, 0.5);
+      circle.anchors_.hcenter_ = ItemRef::scale(filter, kPropertyHeight, 1.5);
       circle.anchors_.vcenter_ = ItemRef::reference(filter, kPropertyVCenter);
       circle.width_ = ItemRef::scale(filter, kPropertyHeight, 0.5);
       circle.height_ = circle.width_;

--- a/apprenticevideo/yaePlaylistView.cpp
+++ b/apprenticevideo/yaePlaylistView.cpp
@@ -1129,6 +1129,7 @@ namespace yae
       (new ModelQuery(model, groupIndex, PlaylistModel::kRoleLabel));
     text.fontSize_ =
       ItemRef::scale(fontSize, kPropertyHeight, 1.07 * kDpiScale);
+    text.supersample_ = text.addExpr(new Supersample<Text>(text));
     text.elide_ = Qt::ElideMiddle;
     text.color_ = ColorRef::constant(style.fg_group_);
     text.background_ = ColorRef::constant(style.bg_group_);
@@ -1278,6 +1279,7 @@ namespace yae
     label.text_ = label.addExpr
       (new ModelQuery(model, index, PlaylistModel::kRoleLabel));
     label.fontSize_ = ItemRef::scale(fontSize, kPropertyHeight, kDpiScale);
+    label.supersample_ = label.addExpr(new Supersample<Text>(label));
     label.background_ = label.
       addExpr(new PremultipliedTransparent(labelBg, kPropertyColor));
     label.color_ = label.

--- a/apprenticevideo/yaePlaylistView.h
+++ b/apprenticevideo/yaePlaylistView.h
@@ -45,7 +45,7 @@ namespace yae
   //----------------------------------------------------------------
   // TClickablePlaylistModelItem
   //
-  typedef ClickableItem<PlaylistModelProxy> TClickablePlaylistModelItem;
+  typedef ClickableModelItem<PlaylistModelProxy> TClickablePlaylistModelItem;
 
   //----------------------------------------------------------------
   // ILayoutDelegate

--- a/apprenticevideo/yaePlaylistViewStyle.cpp
+++ b/apprenticevideo/yaePlaylistViewStyle.cpp
@@ -6,6 +6,9 @@
 // Copyright    : Pavel Koshevoy
 // License      : MIT -- http://www.opensource.org/licenses/mit-license.php
 
+// standard C++ library:
+#include <cmath>
+
 // local interfaces:
 #include "yaePlaylistViewStyle.h"
 #include "yaeText.h"
@@ -91,6 +94,79 @@ namespace yae
     return img;
   }
 
+  //----------------------------------------------------------------
+  // triangleImage
+  //
+  QImage
+  triangleImage(unsigned int w,
+                const Color & color,
+                const Color & background,
+                double rotateAngle)
+  {
+    QImage img(w, w, QImage::Format_ARGB32);
+
+    // supersample each pixel:
+    static const TVec2D sp[] = { TVec2D(0.25, 0.25), TVec2D(0.75, 0.25),
+                                 TVec2D(0.25, 0.75), TVec2D(0.75, 0.75) };
+
+    static const unsigned int supersample = sizeof(sp) / sizeof(TVec2D);
+    static const double sqrt_3 = 1.732050807568877;
+
+    int w2 = w / 2;
+    double diameter = double((w & 1) ? w : w - 1);
+    double radius = diameter * 0.5;
+    double half_r = diameter * 0.25;
+    double base_w = radius * sqrt_3;
+    double half_b = base_w * 0.5;
+    double height = radius + half_r;
+
+    double rotate = M_PI * (1.0 + (rotateAngle / 180.0));
+    TVec2D u_axis(std::cos(rotate), std::sin(rotate));
+    TVec2D v_axis(-u_axis.y(), u_axis.x());
+    TVec2D origin(double(w) - diameter, double(w) - diameter);
+
+    Vec<double, 4> outerColor(background);
+    Vec<double, 4> innerColor(color);
+    TVec2D samplePoint;
+
+    for (int y = 0; y < int(w); y++)
+    {
+      unsigned char * dst = img.scanLine(y);
+      samplePoint.set_y(double(y - w2));
+
+      for (int x = 0; x < int(w); x++, dst += 4)
+      {
+        samplePoint.set_x(double(x - w2));
+
+        double outer = 0.0;
+        double inner = 0.0;
+
+        for (unsigned int k = 0; k < supersample; k++)
+        {
+          TVec2D wcs_pt = samplePoint + sp[k];
+          TVec2D pt = wcs_to_lcs(origin, u_axis, v_axis, wcs_pt);
+
+          double ty = pt.y() + half_r;
+          double t = 1.0 - ty / height;
+          double tb = (t > 1.0) ? 0.0 : (t * half_b);
+          double tx = (tb <= 0.0) ? -1.0 : (1.0 - fabs(pt.x()) / tb);
+          double innerOverlap = (tx >= 0.0);
+          double outerOverlap = 1.0 - innerOverlap;
+
+          outer += outerOverlap;
+          inner += innerOverlap;
+        }
+
+        double outerWeight = outer / double(supersample);
+        double innerWeight = inner / double(supersample);
+        Color c(outerColor * outerWeight + innerColor * innerWeight);
+        memcpy(dst, &(c.argb_), sizeof(c.argb_));
+      }
+    }
+
+    return img;
+  }
+
 
   //----------------------------------------------------------------
   // PlaylistViewStyle::PlaylistViewStyle
@@ -100,7 +176,6 @@ namespace yae
     Item(id),
     playlist_(playlist),
     title_height_(Item::addNewHidden<Item>("title_height")),
-    xbutton_(Item::addHidden<Texture>(new Texture("xbutton", QImage()))),
     cell_width_(Item::addNewHidden<Item>("cell_width")),
     cell_height_(Item::addNewHidden<Item>("cell_height")),
     font_size_(Item::addNewHidden<Item>("font_size")),
@@ -111,6 +186,15 @@ namespace yae
     anchors_.left_ = ItemRef::constant(0);
     width_ = ItemRef::constant(0);
     height_ = ItemRef::constant(0);
+
+    xbutton_ = Item::addHidden<Texture>
+      (new Texture("xbutton", QImage())).sharedPtr<Texture>();
+
+    collapsed_ = Item::addHidden<Texture>
+      (new Texture("collapsed", QImage())).sharedPtr<Texture>();
+
+    expanded_ = Item::addHidden<Texture>
+      (new Texture("expanded", QImage())).sharedPtr<Texture>();
   }
 
   //----------------------------------------------------------------

--- a/apprenticevideo/yaePlaylistViewStyle.cpp
+++ b/apprenticevideo/yaePlaylistViewStyle.cpp
@@ -260,8 +260,28 @@ namespace yae
     cell_height_(Item::addNewHidden<Item>("cell_height")),
     font_size_(Item::addNewHidden<Item>("font_size")),
     now_playing_(Item::addNewHidden<Text>("now_playing")),
-    eyetv_badge_(Item::addNewHidden<Text>("eyetv_badge"))
+    eyetv_badge_(Item::addNewHidden<Text>("eyetv_badge")),
+    font_fixed_("")
   {
+#if (QT_VERSION >= QT_VERSION_CHECK(4, 8, 0))
+    font_fixed_.setHintingPreference(QFont::PreferFullHinting);
+#endif
+    font_fixed_.setFamily("Menlo, "
+                          "Monaco, "
+                          "Droid Sans Mono, "
+                          "DejaVu Sans Mono, "
+                          "Bitstream Vera Sans Mono, "
+                          "Consolas, "
+                          "Lucida Sans Typewriter, "
+                          "Lucida Console, "
+                          "Courier New");
+    font_fixed_.setStyleHint(QFont::Monospace);
+    font_fixed_.setFixedPitch(true);
+    font_fixed_.setStyleStrategy((QFont::StyleStrategy)
+                                 (QFont::PreferOutline |
+                                  QFont::PreferAntialias |
+                                  QFont::OpenGLCompatible));
+
     anchors_.top_ = ItemRef::constant(0);
     anchors_.left_ = ItemRef::constant(0);
     width_ = ItemRef::constant(0);

--- a/apprenticevideo/yaePlaylistViewStyle.h
+++ b/apprenticevideo/yaePlaylistViewStyle.h
@@ -89,6 +89,7 @@ namespace yae
     QFont font_;
     QFont font_small_;
     QFont font_large_;
+    QFont font_fixed_;
 
     enum ColorId
     {

--- a/apprenticevideo/yaePlaylistViewStyle.h
+++ b/apprenticevideo/yaePlaylistViewStyle.h
@@ -40,7 +40,8 @@ namespace yae
   xbuttonImage(unsigned int w,
                const Color & color,
                const Color & background = Color(0x000000, 0.0),
-               double thickness = 0.2);
+               double thickness = 0.2,
+               double rotateAngle = 45.0);
 
   //----------------------------------------------------------------
   // triangleImage
@@ -54,6 +55,17 @@ namespace yae
                 const Color & color,
                 const Color & background = Color(0x0000000, 0.0),
                 double rotateAngle = 0.0);
+
+  //----------------------------------------------------------------
+  // barsImage
+  //
+  YAE_API QImage
+  barsImage(unsigned int w,
+            const Color & color,
+            const Color & background = Color(0x0000000, 0.0),
+            unsigned int nbars = 2,
+            double thickness = 0.8,
+            double rotateAngle = 0.0);
 
   //----------------------------------------------------------------
   // PlaylistViewStyle
@@ -87,6 +99,8 @@ namespace yae
       kScrollbar,
       kSeparator,
       kUnderline,
+      kBgControls,
+      kFgControls,
       kBgXButton,
       kFgXButton,
       kBgFocus,
@@ -124,6 +138,9 @@ namespace yae
     Color scrollbar_;
     Color separator_;
     Color underline_;
+
+    Color bg_controls_;
+    Color fg_controls_;
 
     Color bg_xbutton_;
     Color fg_xbutton_;
@@ -168,6 +185,10 @@ namespace yae
     TTexturePtr xbutton_;
     TTexturePtr collapsed_;
     TTexturePtr expanded_;
+    TTexturePtr pause_;
+    TTexturePtr play_;
+    TTexturePtr grid_on_;
+    TTexturePtr grid_off_;
 
     // layout delegates:
     TPlaylistViewLayoutPtr layout_root_;
@@ -272,6 +293,82 @@ namespace yae
     const PlaylistView & playlist_;
   };
 
+  //----------------------------------------------------------------
+  // StylePauseTexture
+  //
+  struct StylePauseTexture : public TTextureExpr
+  {
+    StylePauseTexture(const PlaylistView & playlist):
+      playlist_(playlist)
+    {}
+
+    // virtual:
+    void evaluate(TTexturePtr & result) const
+    {
+      const PlaylistViewStyle & style = playlist_.playlistViewStyle();
+      result = style.pause_;
+    }
+
+    const PlaylistView & playlist_;
+  };
+
+  //----------------------------------------------------------------
+  // StylePlayTexture
+  //
+  struct StylePlayTexture : public TTextureExpr
+  {
+    StylePlayTexture(const PlaylistView & playlist):
+      playlist_(playlist)
+    {}
+
+    // virtual:
+    void evaluate(TTexturePtr & result) const
+    {
+      const PlaylistViewStyle & style = playlist_.playlistViewStyle();
+      result = style.play_;
+    }
+
+    const PlaylistView & playlist_;
+  };
+
+  //----------------------------------------------------------------
+  // StyleGridOnTexture
+  //
+  struct StyleGridOnTexture : public TTextureExpr
+  {
+    StyleGridOnTexture(const PlaylistView & playlist):
+      playlist_(playlist)
+    {}
+
+    // virtual:
+    void evaluate(TTexturePtr & result) const
+    {
+      const PlaylistViewStyle & style = playlist_.playlistViewStyle();
+      result = style.grid_on_;
+    }
+
+    const PlaylistView & playlist_;
+  };
+
+  //----------------------------------------------------------------
+  // StyleGridOffTexture
+  //
+  struct StyleGridOffTexture : public TTextureExpr
+  {
+    StyleGridOffTexture(const PlaylistView & playlist):
+      playlist_(playlist)
+    {}
+
+    // virtual:
+    void evaluate(TTexturePtr & result) const
+    {
+      const PlaylistViewStyle & style = playlist_.playlistViewStyle();
+      result = style.grid_off_;
+    }
+
+    const PlaylistView & playlist_;
+  };
+
 
   //----------------------------------------------------------------
   // StyleColor
@@ -307,18 +404,39 @@ namespace yae
   //
   struct StyleTitleHeight : public TDoubleExpr
   {
-    StyleTitleHeight(const PlaylistView & playlist):
-      playlist_(playlist)
+    StyleTitleHeight(const PlaylistView & playlist,
+                     double s = 1.0,
+                     double t = 0.0,
+                     bool oddRoundUp = false):
+      playlist_(playlist),
+      scale_(s),
+      translate_(t),
+      oddRoundUp_(oddRoundUp)
     {}
 
     // virtual:
     void evaluate(double & result) const
     {
       const PlaylistViewStyle & style = playlist_.playlistViewStyle();
-      style.title_height_.get(kPropertyHeight, result);
+
+      double v = 0.0;
+      style.title_height_.get(kPropertyHeight, v);
+      v *= scale_;
+      v += translate_;
+
+      if (oddRoundUp_)
+      {
+        int i = 1 | int(ceil(v));
+        v = double(i);
+      }
+
+      result = v;
     }
 
     const PlaylistView & playlist_;
+    double scale_;
+    double translate_;
+    bool oddRoundUp_;
   };
 
 }

--- a/apprenticevideo/yaePlaylistViewStyle.h
+++ b/apprenticevideo/yaePlaylistViewStyle.h
@@ -16,6 +16,7 @@
 // local interfaces:
 #include "yaeColor.h"
 #include "yaePlaylistView.h"
+#include "yaeTexture.h"
 
 
 namespace yae
@@ -23,7 +24,6 @@ namespace yae
 
   // forward declarations:
   class PlaylistView;
-  class Texture;
   class Text;
 
 
@@ -42,6 +42,18 @@ namespace yae
                const Color & background = Color(0x000000, 0.0),
                double thickness = 0.2);
 
+  //----------------------------------------------------------------
+  // triangleImage
+  //
+  // create an image of an equilateral triangle inscribed within
+  // an invisible circle of diameter w, and rotated about the center
+  // of the circle by a given rotation angle (expressed in degrees):
+  //
+  YAE_API QImage
+  triangleImage(unsigned int w,
+                const Color & color,
+                const Color & background = Color(0x0000000, 0.0),
+                double rotateAngle = 0.0);
 
   //----------------------------------------------------------------
   // PlaylistViewStyle
@@ -55,7 +67,6 @@ namespace yae
 
     // shared common properties:
     Item & title_height_;
-    Texture & xbutton_;
     Item & cell_width_;
     Item & cell_height_;
     Item & font_size_;
@@ -153,6 +164,11 @@ namespace yae
     TGradientPtr filter_shadow_;
     TGradientPtr timeline_shadow_;
 
+    // textures:
+    TTexturePtr xbutton_;
+    TTexturePtr collapsed_;
+    TTexturePtr expanded_;
+
     // layout delegates:
     TPlaylistViewLayoutPtr layout_root_;
     TPlaylistViewLayoutPtr layout_group_;
@@ -194,6 +210,63 @@ namespace yae
     {
       const PlaylistViewStyle & style = playlist_.playlistViewStyle();
       result = style.timeline_shadow_;
+    }
+
+    const PlaylistView & playlist_;
+  };
+
+  //----------------------------------------------------------------
+  // StyleXbuttonTexture
+  //
+  struct StyleXbuttonTexture : public TTextureExpr
+  {
+    StyleXbuttonTexture(const PlaylistView & playlist):
+      playlist_(playlist)
+    {}
+
+    // virtual:
+    void evaluate(TTexturePtr & result) const
+    {
+      const PlaylistViewStyle & style = playlist_.playlistViewStyle();
+      result = style.xbutton_;
+    }
+
+    const PlaylistView & playlist_;
+  };
+
+  //----------------------------------------------------------------
+  // StyleCollapsedTexture
+  //
+  struct StyleCollapsedTexture : public TTextureExpr
+  {
+    StyleCollapsedTexture(const PlaylistView & playlist):
+      playlist_(playlist)
+    {}
+
+    // virtual:
+    void evaluate(TTexturePtr & result) const
+    {
+      const PlaylistViewStyle & style = playlist_.playlistViewStyle();
+      result = style.collapsed_;
+    }
+
+    const PlaylistView & playlist_;
+  };
+
+  //----------------------------------------------------------------
+  // StyleExpandedTexture
+  //
+  struct StyleExpandedTexture : public TTextureExpr
+  {
+    StyleExpandedTexture(const PlaylistView & playlist):
+      playlist_(playlist)
+    {}
+
+    // virtual:
+    void evaluate(TTexturePtr & result) const
+    {
+      const PlaylistViewStyle & style = playlist_.playlistViewStyle();
+      result = style.expanded_;
     }
 
     const PlaylistView & playlist_;

--- a/apprenticevideo/yaeRoundRect.cpp
+++ b/apprenticevideo/yaeRoundRect.cpp
@@ -149,7 +149,7 @@ namespace yae
       }
     }
 
-    bool ok = yae::uploadTexture2D(img, texId_, iw_, iw_, GL_NEAREST);
+    bool ok = yae::uploadTexture2D(img, texId_, GL_NEAREST);
     return ok;
   }
 

--- a/apprenticevideo/yaeText.h
+++ b/apprenticevideo/yaeText.h
@@ -66,6 +66,30 @@ namespace yae
 
 
   //----------------------------------------------------------------
+  // Supersample
+  //
+  template <typename TFontSizeItem>
+  struct Supersample : public TDoubleExpr
+  {
+    Supersample(const TFontSizeItem & item, double minFontSize = 72.0):
+      item_(item),
+      minFontSize_(minFontSize)
+    {}
+
+    // virtual:
+    void evaluate(double & result) const
+    {
+      double fontSize = item_.fontSize_.get();
+      result = std::max<double>(1.0, minFontSize_ / fontSize);
+      result = std::min<double>(8.0, result);
+    }
+
+    const TFontSizeItem & item_;
+    double minFontSize_;
+  };
+
+
+  //----------------------------------------------------------------
   // Text
   //
   class Text : public Item
@@ -122,6 +146,7 @@ namespace yae
 
     TVarRef text_;
     ItemRef fontSize_; // in points
+    ItemRef supersample_;
     ItemRef maxWidth_;
     ItemRef maxHeight_;
     ColorRef color_;

--- a/apprenticevideo/yaeTextInput.h
+++ b/apprenticevideo/yaeTextInput.h
@@ -89,6 +89,7 @@ namespace yae
 
     QFont font_;
     ItemRef fontSize_; // in points
+    ItemRef supersample_;
     ItemRef cursorWidth_; // in pixels
 
     ColorRef color_;

--- a/apprenticevideo/yaeTexture.cpp
+++ b/apprenticevideo/yaeTexture.cpp
@@ -19,13 +19,38 @@ namespace yae
 {
 
   //----------------------------------------------------------------
+  // downsampleImage
+  //
+  unsigned int
+  downsampleImage(QImage & img, double supersampled)
+  {
+    unsigned int n = 1;
+
+    while (supersampled >= 2.0)
+    {
+      n *= 2;
+      supersampled /= 2.0;
+    }
+
+    if (n > 1)
+    {
+      int iw = img.width();
+      int ih = img.height();
+      img = img.scaled(iw / n,
+                       ih / n,
+                       Qt::IgnoreAspectRatio,
+                       Qt::SmoothTransformation);
+    }
+
+    return n;
+  }
+
+  //----------------------------------------------------------------
   // uploadTexture2D
   //
   bool
   uploadTexture2D(const QImage & img,
                   GLuint & texId,
-                  GLuint & iw,
-                  GLuint & ih,
                   GLenum textureFilterMin,
                   GLenum textureFilterMag)
   {
@@ -47,8 +72,8 @@ namespace yae
       return false;
     }
 
-    iw = img.width();
-    ih = img.height();
+    GLuint iw = img.width();
+    GLuint ih = img.height();
     GLsizei widthPowerOfTwo = powerOfTwoGEQ<GLsizei>(iw);
     GLsizei heightPowerOfTwo = powerOfTwoGEQ<GLsizei>(ih);
 
@@ -311,8 +336,8 @@ namespace yae
   Texture::TPrivate::TPrivate(const QImage & image):
     image_(image),
     texId_(0),
-    iw_(0),
-    ih_(0),
+    iw_(image.width()),
+    ih_(image.height()),
     u1_(0.0),
     v1_(0.0)
   {}
@@ -336,7 +361,7 @@ namespace yae
   bool
   Texture::TPrivate::uploadTexture(const Texture & item)
   {
-    bool ok = yae::uploadTexture2D(image_, texId_, iw_, ih_,
+    bool ok = yae::uploadTexture2D(image_, texId_,
                                    // should this be a user option?
                                    GL_LINEAR_MIPMAP_LINEAR);
 

--- a/apprenticevideo/yaeTexture.h
+++ b/apprenticevideo/yaeTexture.h
@@ -84,6 +84,21 @@ namespace yae
     TPrivate * p_;
   };
 
+  //----------------------------------------------------------------
+  // TTexturePtr
+  //
+  typedef boost::shared_ptr<Texture> TTexturePtr;
+
+  //----------------------------------------------------------------
+  // TTextureRef
+  //
+  typedef DataRef<TTexturePtr> TTextureRef;
+
+  //----------------------------------------------------------------
+  // TTextureExpr
+  //
+  typedef Expression<TTexturePtr> TTextureExpr;
+
 }
 
 

--- a/apprenticevideo/yaeTexture.h
+++ b/apprenticevideo/yaeTexture.h
@@ -21,13 +21,23 @@ namespace yae
 {
 
   //----------------------------------------------------------------
+  // downsampleImage
+  //
+  // Supersampled texture should not be uploaded at full resolution,
+  // it should be scaled down first:
+  //
+  // returns power-of-two factor that was used to scale down
+  // given supersampled image
+  //
+  unsigned int
+  downsampleImage(QImage & img, double supersampled);
+
+  //----------------------------------------------------------------
   // uploadTexture2D
   //
   bool
   uploadTexture2D(const QImage & img,
                   GLuint & texId,
-                  GLuint & iw,
-                  GLuint & ih,
                   GLenum textureFilterMin,
                   GLenum textureFilterMag = GL_LINEAR);
 

--- a/apprenticevideo/yaeTexturedRect.cpp
+++ b/apprenticevideo/yaeTexturedRect.cpp
@@ -19,10 +19,19 @@ namespace yae
   //----------------------------------------------------------------
   // TexturedRect::TexturedRect
   //
-  TexturedRect::TexturedRect(const char * id, const Texture & texture):
-    Item(id),
-    texture_(texture)
+  TexturedRect::TexturedRect(const char * id):
+    Item(id)
   {}
+
+  //----------------------------------------------------------------
+  // TexturedRect::uncache
+  //
+  void
+  TexturedRect::uncache()
+  {
+    texture_.uncache();
+    Item::uncache();
+  }
 
   //----------------------------------------------------------------
   // TexturedRect::paintContent
@@ -30,9 +39,17 @@ namespace yae
   void
   TexturedRect::paintContent() const
   {
+    const TTexturePtr & texturePtr = texture_.get();
+    if (!texturePtr)
+    {
+      YAE_ASSERT(false);
+      return;
+    }
+
+    const Texture & texture = *texturePtr;
     double u1 = 0.0;
     double v1 = 0.0;
-    if (!texture_.bind(u1, v1))
+    if (!texture.bind(u1, v1))
     {
       return;
     }
@@ -62,6 +79,6 @@ namespace yae
     }
     YAE_OGL_11(glEnd());
 
-    texture_.unbind();
+    texture.unbind();
   }
 }

--- a/apprenticevideo/yaeTexturedRect.h
+++ b/apprenticevideo/yaeTexturedRect.h
@@ -19,18 +19,17 @@ namespace yae
   //----------------------------------------------------------------
   // TexturedRect
   //
-  class TexturedRect : public Item
+  struct TexturedRect : public Item
   {
-    TexturedRect(const TexturedRect &);
-    TexturedRect & operator = (const TexturedRect &);
+    TexturedRect(const char * id);
 
-  public:
-    TexturedRect(const char * id, const Texture & texture);
+    // virtual:
+    void uncache();
 
     // virtual:
     void paintContent() const;
 
-    const Texture & texture_;
+    TTextureRef texture_;
   };
 
 }

--- a/apprenticevideo/yaeTimelineView.cpp
+++ b/apprenticevideo/yaeTimelineView.cpp
@@ -617,28 +617,8 @@ namespace yae
       root.add(new SliderOutPoint(*this, timeline));
     sliderOutPoint.anchors_.offset(outPoint, -1, 0, -1, 0);
 
-    QFont timecodeFont("");
-#if (QT_VERSION >= QT_VERSION_CHECK(4, 8, 0))
-    timecodeFont.setHintingPreference(QFont::PreferFullHinting);
-#endif
-#if 1
-    timecodeFont.setFamily("Menlo, "
-                           "Monaco, "
-                           "Droid Sans Mono, "
-                           "DejaVu Sans Mono, "
-                           "Bitstream Vera Sans Mono, "
-                           "Consolas, "
-                           "Lucida Sans Typewriter, "
-                           "Lucida Console, "
-                           "Courier New");
-#endif
-
-    timecodeFont.setStyleHint(QFont::Monospace);
-    timecodeFont.setFixedPitch(true);
-    timecodeFont.setStyleStrategy((QFont::StyleStrategy)
-                                  (QFont::PreferOutline |
-                                   QFont::PreferAntialias |
-                                   QFont::OpenGLCompatible));
+    const PlaylistViewStyle & style = playlist->playlistViewStyle();
+    QFont timecodeFont = style.font_fixed_;
 
     Rectangle & playheadAuxBg = container.addNew<Rectangle>("playheadAuxBg");
     Text & playheadAux = container.addNew<Text>("playheadAux");


### PR DESCRIPTION
* Add a button in the upper left corner for toggling playlist, visible when either timeline or playlist is visible, otherwise revealed on mouse-over.
* Add a player controls group (one button so far) always hidden when playlist is visible, otherwise revealed on mouse-over.
* Fix an Item layout bug due to incorrect addition of bottom margin when referencing the bottom of an item
* Enable playlist item title text supersampling as a workaround for ugly text rendering in Qt5.